### PR TITLE
Draft: Add OpenTelemetry metrics endpoint and instrumentation libs

### DIFF
--- a/NotesAppDotnet/NotesAppDotnet/NotesAppDotnet.csproj
+++ b/NotesAppDotnet/NotesAppDotnet/NotesAppDotnet.csproj
@@ -14,6 +14,12 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="6.0.0" />
+        <PackageReference Include="OpenTelemetry" Version="1.3.0-beta.2" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-beta.2" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="0.1.0-alpha.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     </ItemGroup>
 

--- a/NotesAppDotnet/NotesAppDotnet/Program.cs
+++ b/NotesAppDotnet/NotesAppDotnet/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using NotesAppDotnet.Data;
 using NotesAppDotnet.Model;
+using OpenTelemetry.Metrics;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,11 +18,24 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Host.UseSystemd();
 
+// https://opentelemetry.io/docs/instrumentation/net/automatic/
+builder.Services.AddOpenTelemetryMetrics(otel =>
+{
+    // Add instrumentation - metrics providers
+    // CPU / Memory  + GC activity aka Runtime Metrics
+    otel.AddRuntimeMetrics();
+    // HTTP Server call durations per return code
+    otel.AddAspNetCoreInstrumentation();
+
+    // Register Prometheus as OTEL exporter
+    otel.AddPrometheusExporter();
+});
+
 var app = builder.Build();
 
 app.UseSwagger();
 app.UseSwaggerUI();
-
+app.UseOpenTelemetryPrometheusScrapingEndpoint();
 // Configure the HTTP request pipeline.
 // if (app.Environment.IsDevelopment())
 // {


### PR DESCRIPTION
Example metrics endpoint (keep it for now as a reference)
To get "golden signals" monitoring we need to wait for next OTEL release (endpoint names as a metric tag/dimention) https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md#unreleased

```
# HELP process_runtime_dotnet_gc_heap_By GC Heap Size
# TYPE process_runtime_dotnet_gc_heap_By gauge
process_runtime_dotnet_gc_heap_By 8316920 1653291589656

# HELP process_runtime_dotnet_gen_0_gc_count Gen 0 GC Count
# TYPE process_runtime_dotnet_gen_0_gc_count gauge
process_runtime_dotnet_gen_0_gc_count 0 1653291589656

# HELP process_runtime_dotnet_gen_1_gc_count Gen 1 GC Count
# TYPE process_runtime_dotnet_gen_1_gc_count gauge
process_runtime_dotnet_gen_1_gc_count 0 1653291589656

# HELP process_runtime_dotnet_gen_2_gc_count Gen 2 GC Count
# TYPE process_runtime_dotnet_gen_2_gc_count gauge
process_runtime_dotnet_gen_2_gc_count 0 1653291589656

# HELP process_runtime_dotnet_alloc_rate_By Allocation Rate
# TYPE process_runtime_dotnet_alloc_rate_By counter
process_runtime_dotnet_alloc_rate_By 8300288 1653291589656

# HELP process_runtime_dotnet_gc_fragmentation GC Fragmentation
# TYPE process_runtime_dotnet_gc_fragmentation counter
process_runtime_dotnet_gc_fragmentation 0 1653291589656

# HELP process_runtime_dotnet_gc_committed_Mi GC Committed Bytes
# TYPE process_runtime_dotnet_gc_committed_Mi counter
process_runtime_dotnet_gc_committed_Mi 0 1653291589656

# HELP process_runtime_dotnet_il_bytes_jitted_By IL Bytes Jitted
# TYPE process_runtime_dotnet_il_bytes_jitted_By counter
process_runtime_dotnet_il_bytes_jitted_By 430424 1653291589656

# HELP process_runtime_dotnet_methods_jitted_count Number of Methods Jitted
# TYPE process_runtime_dotnet_methods_jitted_count counter
process_runtime_dotnet_methods_jitted_count 6140 1653291589656

# HELP process_runtime_dotnet_time_in_jit_ms Time spent in JIT
# TYPE process_runtime_dotnet_time_in_jit_ms gauge
process_runtime_dotnet_time_in_jit_ms 1202.2287 1653291589656

# HELP process_runtime_dotnet_monitor_lock_contention_count Monitor Lock Contention Count
# TYPE process_runtime_dotnet_monitor_lock_contention_count gauge
process_runtime_dotnet_monitor_lock_contention_count 0 1653291589656

# HELP process_runtime_dotnet_threadpool_thread_count ThreadPool Thread Count
# TYPE process_runtime_dotnet_threadpool_thread_count counter
process_runtime_dotnet_threadpool_thread_count 5 1653291589656

# HELP process_runtime_dotnet_threadpool_completed_items_count ThreadPool Completed Work Item Count
# TYPE process_runtime_dotnet_threadpool_completed_items_count gauge
process_runtime_dotnet_threadpool_completed_items_count 34 1653291589656

# HELP process_runtime_dotnet_threadpool_queue_length ThreadPool Queue Length
# TYPE process_runtime_dotnet_threadpool_queue_length counter
process_runtime_dotnet_threadpool_queue_length 0 1653291589656

# HELP process_runtime_dotnet_active_timer_count Number of Active Timers
# TYPE process_runtime_dotnet_active_timer_count counter
process_runtime_dotnet_active_timer_count 3 1653291589656

# HELP process_cpu_time_s Processor time of this process
# TYPE process_cpu_time_s counter
process_cpu_time_s{state="user"} 1.43 1653291589656
process_cpu_time_s{state="system"} 0.07 1653291589656

# HELP process_cpu_count The number of available logical CPUs
# TYPE process_cpu_count gauge
process_cpu_count 12 1653291589656

# HELP process_memory_usage_By The amount of physical memory in use
# TYPE process_memory_usage_By gauge
process_memory_usage_By 98459648 1653291589656

# HELP process_memory_virtual_By The amount of committed virtual memory
# TYPE process_memory_virtual_By gauge
process_memory_virtual_By 23666937856 1653291589656

# HELP process_runtime_dotnet_assembly_count Number of Assemblies Loaded
# TYPE process_runtime_dotnet_assembly_count counter
process_runtime_dotnet_assembly_count 136 1653291589656

# HELP http_server_duration_ms measures the duration of the inbound HTTP request
# TYPE http_server_duration_ms histogram
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="0"} 0 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="5"} 0 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="10"} 0 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="25"} 0 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="50"} 0 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="75"} 1 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="100"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="250"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="500"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="1000"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200",le="+Inf"} 2 1653291589656
http_server_duration_ms_sum{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200"} 146.1769 1653291589656
http_server_duration_ms_count{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="200"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="0"} 0 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="5"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="10"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="25"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="50"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="75"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="100"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="250"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="500"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="1000"} 2 1653291589656
http_server_duration_ms_bucket{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404",le="+Inf"} 2 1653291589656
http_server_duration_ms_sum{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404"} 0.5815 1653291589656
http_server_duration_ms_count{http_flavor="HTTP/1.1",http_method="GET",http_scheme="http",http_status_code="404"} 2 1653291589656
```