### PR TITLE
Draft: Add OpenTelemetry Jeager tracing support

### DIFF
--- a/NotesAppDotnet/NotesAppDotnet/NotesAppDotnet.csproj
+++ b/NotesAppDotnet/NotesAppDotnet/NotesAppDotnet.csproj
@@ -14,6 +14,12 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="6.0.0" />
+        <PackageReference Include="OpenTelemetry" Version="1.3.0-beta.2" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-beta.2" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="0.1.0-alpha.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     </ItemGroup>
 

--- a/NotesAppDotnet/NotesAppDotnet/NotesAppDotnet.csproj
+++ b/NotesAppDotnet/NotesAppDotnet/NotesAppDotnet.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="6.0.0" />
         <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
         <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.3" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" />

--- a/NotesAppDotnet/NotesAppDotnet/NotesAppDotnet.csproj
+++ b/NotesAppDotnet/NotesAppDotnet/NotesAppDotnet.csproj
@@ -14,13 +14,12 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="6.0.0" />
-        <PackageReference Include="OpenTelemetry" Version="1.3.0-beta.2" />
-        <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-beta.2" />
+        <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.3" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" />
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.3" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="0.1.0-alpha.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="0.2.0-alpha.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     </ItemGroup>
-
 </Project>

--- a/NotesAppDotnet/NotesAppDotnet/Program.cs
+++ b/NotesAppDotnet/NotesAppDotnet/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using NotesAppDotnet.Data;
 using NotesAppDotnet.Model;
+using OpenTelemetry.Metrics;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,11 +18,24 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Host.UseSystemd();
 
+// https://opentelemetry.io/docs/instrumentation/net/automatic/
+builder.Services.AddOpenTelemetryMetrics(otel =>
+{
+    // Add instrumentation - metrics providers
+    // CPU / Memory  + GC activity aka Runtime Metrics
+    otel.AddRuntimeMetrics();
+    // HTTP Server call durations per return code
+    otel.AddAspNetCoreInstrumentation();
+
+    // Register Prometheus as OTEL exporter
+    otel.AddPrometheusExporter();
+});
+
 var app = builder.Build();
 
 app.UseSwagger();
 app.UseSwaggerUI();
-
+app.UseOpenTelemetryPrometheusScrapingEndpoint();
 // Configure the HTTP request pipeline.
 // if (app.Environment.IsDevelopment())
 // {


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/trace/getting-started-jaeger/README.md 

Basic handling of OTEL Tracing & automatic OTEL to Jeager export (works with Jeager all-in-one container)

![image](https://user-images.githubusercontent.com/103517095/173246915-2cba12a9-f6a7-42db-bddb-d4462962ef2b.png)
